### PR TITLE
Subclass azuredlfile

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -163,15 +163,18 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
         self.do_connect()
 
 
-class AzureDatalakeFile(AzureDLFile):
+class AzureDatalakeFile(AbstractBufferedFile):
     def __init__(self, fs, path, mode='rb'):
-        super().__init__(azure=fs.azure_fs, path=path, mode=mode)
         self.fs = fs
         self.path = AzureDLPath(path)
-        # self.make_azure_dl_file(azure = self.fs.azure_fs, path=self.path, mode=self.mode)
+        self.mode = mode
+        self.loc = 0
+        self.closed = False
+        self._closed = None
+        self.make_azure_dl_file(azure = self.fs.azure_fs, path=self.path, mode=self.mode)
         
-    # def make_azure_dl_file(self, azure, path, mode, blocksize=2**25, delimiter=None):
-    #     self.azurefile = AzureDLFile(azure=azure, path=AzureDLPath(path), mode=mode, blocksize=blocksize, delimiter=delimiter)
+    def make_azure_dl_file(self, azure, path, mode, blocksize=2**25, delimiter=None):
+        self.azurefile = AzureDLFile(azure=azure, path=AzureDLPath(path), mode=mode, blocksize=blocksize, delimiter=delimiter)
     
     # # def _fetch_range(self, start, end):
     # #     self.azurefile._fetch(start, end)
@@ -180,11 +183,14 @@ class AzureDatalakeFile(AzureDLFile):
     #     out = self.azurefile.read(length=length)
     #     return out
     
-    # def write(self, data):
-    #     self.azurefile.write(data)
+    def write(self, data):
+        return self.azurefile.write(data)
         
-    # def flush(self, force=False):
-    #     self.azurefile.flush(force=force)
+    def flush(self, force=False):
+        return self.azurefile.flush(force=force)
+    
+    def close(self):
+        return self.azurefile.close()
     
     # def seek(self, loc, whence=0):
     #     return self.azurefile.seek(loc=loc, whence=whence)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os import path
 
 
 setup(name='adlfs',
-      version='0.0.6',
+      version='0.0.7',
       description='Access Azure Datalake Gen1 with fsspec and dask',
       url='https://github.com/hayesgb/adlfs/',
       maintainer='Greg Hayes',


### PR DESCRIPTION
Dask now implements the read_block method from fsspec.  The Azure datalake store sdk implementation of the seek() method on AzureDLFile fails to read from the datalake when called from fsspec.utils.read_block().  Overriding the AzureDLFile seek method with fsspec's seek method fixes this problem.