### PR TITLE
Update gen1 gettr settr

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -150,23 +150,18 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
     def __getstate__(self):
         try:
             dic = self.__dict__.copy()
-            # dic = self.azure_fs.__dict__.copy()
+            # Need to determine what information can be deleted
+            # before passing to the Dask workers
             # del dic['token']
             # del dic['azure']
             logger.debug("Serialize with state: %s", dic)
             return dic
-        except AttributeError:
-            self.do_connect()
-            self.__getstate__()
 
     def __setstate__(self, state):
         try:
             logger.debug("De-serialize with state: %s", state)
-            # self.azure_fs.__dict__.update(state)
             self.__dict__.update(state)
             self.do_connect()
-        except AttributeError:
-            self.__setstate__(state)
 
 
 class AzureDatalakeFile(AzureDLFile):

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -148,16 +148,25 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
         return self.info(path)['length']
 
     def __getstate__(self):
-        dic = self.__dict__.copy()
-        del dic['token']
-        del dic['azure']
-        logger.debug("Serialize with state: %s", dic)
-        return dic
+        try:
+            dic = self.__dict__.copy()
+            # dic = self.azure_fs.__dict__.copy()
+            # del dic['token']
+            # del dic['azure']
+            logger.debug("Serialize with state: %s", dic)
+            return dic
+        except AttributeError:
+            self.do_connect()
+            self.__getstate__()
 
     def __setstate__(self, state):
-        logger.debug("De-serialize with state: %s", state)
-        self.__dict__.update(state)
-        self.do_connect()
+        try:
+            logger.debug("De-serialize with state: %s", state)
+            # self.azure_fs.__dict__.update(state)
+            self.__dict__.update(state)
+            self.do_connect()
+        except AttributeError:
+            self.__setstate__(state)
 
 
 class AzureDatalakeFile(AzureDLFile):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os import path
 
 
 setup(name='adlfs',
-      version='0.0.7',
+      version='0.0.8post4',
       description='Access Azure Datalake Gen1 with fsspec and dask',
       url='https://github.com/hayesgb/adlfs/',
       maintainer='Greg Hayes',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os import path
 
 
 setup(name='adlfs',
-      version='0.0.8post4',
+      version='0.0.9',
       description='Access Azure Datalake Gen1 with fsspec and dask',
       url='https://github.com/hayesgb/adlfs/',
       maintainer='Greg Hayes',


### PR DESCRIPTION
The __getstate__ and __setstate__ methods for AzureDatalakeFileSystem were not serializing filesystem information to Dask workers, leaving the workers unable to access Gen1 files.  This has been corrected.