### PR TITLE
Resolve parquet walk

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -205,7 +205,6 @@ class AzureBlobFileSystem(AbstractFileSystem):
 
     This exposes a filesystem-like API on top of Azure Datalake Gen2 and Azure Storage.
     
-    Note:  dask.dataframe.read_parquet() method currently only works with "engine=pyarrow"
 
     Examples
     _________
@@ -215,6 +214,10 @@ class AzureBlobFileSystem(AbstractFileSystem):
         Sharded Parquet & csv files can be read as:
         ----------------------------
         ddf = dd.read_csv('abfs://container_name/folder/*.csv', storage_options={
+            'account_name': ACCOUNT_NAME, 'account_key': ACCOUNT_KEY,
+        })
+        
+        ddf = dd.read_parquet('abfs://container_name/folder.parquet', storage_options={
             'account_name': ACCOUNT_NAME, 'account_key': ACCOUNT_KEY,
         })
     """
@@ -239,17 +242,18 @@ class AzureBlobFileSystem(AbstractFileSystem):
     @staticmethod
     def _get_kwargs_from_urls(paths):
         """ Get the store_name from the urlpath and pass to storage_options """
+        logging.debug('Getting kwargs from urls...')
         ops = infer_storage_options(paths)
         out = {}
         if ops.get('host', None):
             out['container_name'] = ops['host']
-        logging.debug(f'_get_kwargs_from_urls:  {out}')
+        logging.debug(f'kwargs are:  {out}')
         return out
     
     @classmethod
     def _strip_protocol(cls, path):
         ops = infer_storage_options(path)
-        ops['path'] = ops['path'].strip('/')
+        ops['path'] = ops['path'].lstrip('/')
         logging.debug(f'_strip_protocol:  {ops}')
         return ops['path']
     
@@ -267,7 +271,6 @@ class AzureBlobFileSystem(AbstractFileSystem):
         """
         logging.debug("Running abfs.ls() method")
         path = stringify_path(path)
-        logging.debug(f'Stringified path:  {path}')
         blobs = self.blob_fs.list_blobs(container_name=self.container_name, prefix=path)
         if detail is False:
             pathlist = [blob.name for blob in blobs]
@@ -326,7 +329,7 @@ class AzureBlobFileSystem(AbstractFileSystem):
         kwargs: passed to ``ls``
         """
         
-        logging.debug("Walking the filepath structure")
+        logging.debug(f"abfs.walk() for {path}")
         path = self._strip_protocol(path)
         full_dirs = []
         dirs = []
@@ -341,27 +344,32 @@ class AzureBlobFileSystem(AbstractFileSystem):
             # each info name must be at least [path]/part , but here
             # we check also for names like [path]/part/
             name = info["name"].rstrip("/")
-            logging.debug(f"Test path with name:  {name}, {path}, {info['type']}")
-            if info["type"] == "directory" and name != path:
+            logging.debug(f"Test path with name, path, type, size:  {name}, {path}, {info['type']}, {info['size']}")
+            if info["type"] == "directory" and name != path and info['size'] == 0:
                 logging.debug(f'{name} is a directory')
+                logging.debug(f'compare name and path: {name}, {path}')
                 # do not include "self" path
                 full_dirs.append(name)
                 # Need to add this line to handle an oddity in how
                 # Azure Storage returns blob paths from list operations.
                 # Without it, the ParquetDataset operation by pyarrow fails
                 logging.debug(f"Path name:  {name} is a directory.  Evaluate against {path}")
-                # if path.lstrip('/') != name:
-                #     logging.debug(f"Appended {name} to dirs.")
                 dirs.append(name.rsplit("/", 1)[-1])
-            elif name == path:
+            elif info['type'] == 'directory' and name == path and info['size'] == 0:
+                logging.debug(f'Skipping {name}.  It is the current directory')
+                # The Azure Blob Storage SDK returns the path from a list_blobs()
+                # method call.  This creates an inconsistency across dasks's read methods 
+                # Specifically (read_csv(fpath/fname.csv/*.csv), and the fastparquet vs pyarrow 
+                # read_parquet(fpath/fname.parquet) implement a glob call.  Adding
+                # this line reconciles those differences
+                continue
+            elif name == path and info['type'] == 'file':
                 logging.debug(f'name == path')
                 # file-like with same name as give path
                 files.append("")
             else:
-                logging.debug(f'this is a file')
+                logging.debug(f'{name} is a file')
                 files.append(name.rsplit("/", 1)[-1])
-            
-        logging.debug(dirs)    
         yield path, dirs, files
 
         for d in full_dirs:

--- a/adlfs/tests/test_core.py
+++ b/adlfs/tests/test_core.py
@@ -6,7 +6,15 @@ from dask.bytes.core import read_bytes
 
 from adlfs.core import AzureBlobFileSystem, AzureBlobFile
 
+## Tests against AzureBlobFileSystem
+        
+class MockBlockBlobService:
+    @staticmethod
+    def get_blob_properties(container_name, blob_name):
+        blob = TestBlob()
+        return blob
 
+# Fixture that sets up the AzureBlobFileSystem for calls
 @pytest.fixture()
 def test_mock_abfs(monkeypatch):
     tenant_id = 'test_tenant'
@@ -14,17 +22,27 @@ def test_mock_abfs(monkeypatch):
     client_secret = 'client_secret'
     storage_account = 'test_storage_account'
     filesystem = 'test_filesystem'
+    account_name = 'test_account'
+    account_key = 'test_key'
+    container_name = 'test_container'
     
-    def mock_connect(conn):
-        return "None"
+    def mock_
     
-    monkeypatch.setattr(AzureBlobFileSystem, "connect", mock_connect)
+    def mock_do_connect(conn):
+        conn.blob_fs = MockBlockBlobService()
+        return conn
     
-    mock_fs = AzureBlobFileSystem(tenant_id=tenant_id, client_id=client_id,
-                                client_secret=client_secret, 
-                                storage_account=storage_account, filesystem=filesystem,
+    monkeypatch.setattr(AzureBlobFileSystem, "do_connect", mock_do_connect)
+    
+    mock_fs = AzureBlobFileSystem(account_name=account_name, account_key=account_key,
+                                  container_name=container_name
                                 )
     return mock_fs
+
+
+def test__strip_protocol(test_mock_abfs):
+    fs = test_mock_abfs
+    path
 
 def test_make_url(test_mock_abfs):
     fs = test_mock_abfs
@@ -90,7 +108,7 @@ def test_info(test_mock_abfs):
                         'x-ms-resource-type': 'file'},
             )
     mock_abfs = test_mock_abfs
-    mock_details = mock_abfs.info("testfile.csv")
+    mock_details = mock_abfs.blob_fs.info("testfile.csv")
     assert mock_details == {'name': 'testfile.csv', 'size': 10, 'type': 'file'}
 
 @responses.activate

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name='adlfs',
       long_description=open('README.rst').read() if exists('README.rst') else '',
       install_requires=['azure-datalake-store',
                         'fsspec>=0.4.0<1.0',
-                        'azure-storage-blob==2.1.0'
+                        'azure-storage-blob==2.1.0',
+                        'pyarrow>=0.15.0',
                         ],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from os import path
 
 
 setup(name='adlfs',
-      version='0.0.11',
+      version='0.1.0',
       description='Access Azure Datalake Gen1 with fsspec and dask',
       url='https://github.com/hayesgb/adlfs/',
       maintainer='Greg Hayes',


### PR DESCRIPTION
This fixes an issue with the abfs.walk() method that was creating inconsistencies in reading a pyarrow ParquetDataset from Azure Storage.